### PR TITLE
fixing Chromium macro conflicts

### DIFF
--- a/tweetnacl.cc
+++ b/tweetnacl.cc
@@ -6,7 +6,11 @@
 
 #if defined _WINDOWS
 #define NOGDI
+
+#if !defined CHROMIUM_BUILD
 #define NOMINMAX
+#endif
+
 #include <windows.h>
 #include <Wincrypt.h>
 #else


### PR DESCRIPTION
Resolved conflict: the macro NOMINMAX has been defined. (Windows Chromium build)