### PR TITLE
Removed Chromium specific definition.

### DIFF
--- a/tweetnacl.cc
+++ b/tweetnacl.cc
@@ -7,7 +7,7 @@
 #if defined _WINDOWS
 #define NOGDI
 
-#if !defined CHROMIUM_BUILD
+#ifndef NOMINMAX
 #define NOMINMAX
 #endif
 


### PR DESCRIPTION
For Windows NOMINMAX needs to be defined due to the use of
std::numeric_limits<u32>::max. To guard against redefinition
an #ifndef NOMINMAX can be used.